### PR TITLE
Add classes to bricks

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -319,8 +319,13 @@ function loadEagerImages() {
 }
 
 function transformToCustomElement(brick) {
-  const tagName = `aem-${brick.getAttribute('class')?.split(' ')[0] || brick.tagName.toLowerCase()}`;
+  const { classList } = brick;
+  const brickName = classList[0];
+  const brickClasses = [...classList].slice(1);
+
+  const tagName = `aem-${brickName || brick.tagName.toLowerCase()}`;
   const customElement = document.createElement(tagName);
+  customElement.classList.add(...brickClasses);
 
   customElement.innerHTML = brick.innerHTML;
 


### PR DESCRIPTION
Test URLs:
- Before: https://main--helix-website-wc--adobe-gw2023-project-bricks.hlx.page/home
- After: https://add_classes--helix-website-wc--adobe-gw2023-project-bricks.hlx.page/home

They can be used within css with:
`:host(.<className>)`
And from the component js with:
`this.classList`