### PR TITLE
Root Brick

### DIFF
--- a/bricks/aem-root/aem-root.html
+++ b/bricks/aem-root/aem-root.html
@@ -1,0 +1,46 @@
+<template>
+  <style>
+    :host {
+      font-size: var(--body-font-size-m);
+      font-family: var(--body-font-family);
+      line-height: 1.6;
+      color: var(--text-color);
+      background-color: var(--background-color);
+    }
+
+    header {
+      height: var(--nav-height);
+    }
+
+    .section {
+      padding: 64px 16px;
+    }
+
+    .wrapper {
+      max-width: 1200px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    @media (width >= 600px) {
+      .section {
+        padding: 64px 32px;
+      }
+    }
+
+    /* section metadata */
+    .section.highlight {
+      background-color: var(--highlight-background-color);
+    }
+  </style>
+
+  <body>
+    <aem-header></aem-header>
+
+    <main>
+      <slot name="main"></slot>
+    </main>
+
+    <aem-footer></aem-footer>
+  </body>
+</template>

--- a/bricks/aem-root/aem-root.js
+++ b/bricks/aem-root/aem-root.js
@@ -1,0 +1,28 @@
+import { Brick } from '../../scripts/aem.js';
+
+export default class Footer extends Brick {
+  async connectedCallback() {
+    // Main Sections
+    const main = this.shadowRoot.querySelector('slot[name="main"]');
+    main.innerHTML = this.root.querySelector('main').innerHTML;
+
+    // Decorate Sections
+    [...main.children].forEach((section) => {
+      // Purge empty DIVs
+      if (section.children.length === 0) {
+        section.remove();
+        return;
+      }
+
+      // Sections
+      if (section.tagName === 'DIV') {
+        section.classList.add('wrapper');
+
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('section');
+        section.parentNode.insertBefore(wrapper, section);
+        wrapper.appendChild(section);
+      }
+    });
+  }
+}

--- a/bricks/aem-section-metadata/aem-section-metadata.js
+++ b/bricks/aem-section-metadata/aem-section-metadata.js
@@ -8,9 +8,9 @@ export default class SectionMetadata extends Brick {
   connectedCallback() {
     [...this.values].forEach(([key, value]) => {
       if (key.toLowerCase() === 'style') {
-        this.parentElement.classList.add(value);
+        this.parentElement.parentElement.classList.add(value);
       } else {
-        this.parentElement.dataset[key] = value;
+        this.parentElement.parentElement.dataset[key] = value;
       }
     });
   }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -444,13 +444,8 @@ export default async function initialize() {
   // Decorate Root
   decorateRoot();
 
-  // Load common brick styles
-  if (css.value) {
-    window.hlx.blockStyles = css.value;
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(css.value);
-    document.adoptedStyleSheets = [sheet];
-  }
+  // common brick styles
+  window.hlx.blockStyles = css.value;
 
   // Define custom elements
   loadedComponents.value.forEach(async ({ status, value }) => {
@@ -516,12 +511,12 @@ export class Brick extends HTMLElement {
 
     const slots = this.querySelectorAll('[slot="item"]');
 
-    slots.forEach((element) => {
-      if (options.mapValues) {
+    if (options.mapValues) {
+      slots.forEach((element) => {
         const [key, value] = element.children;
         this.values.set(key.innerText, value.innerHTML);
-      }
-    });
+      });
+    }
 
     // clone root
     const root = document.createElement('div');

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -103,6 +103,8 @@ async function loadFonts() {
  * @param {span} [element] span element with icon classes
  */
 function decorateIcon(elem) {
+  if (elem.dataset.decorated) return;
+
   const iconName = Array.from(elem.classList)
     .find((c) => c.startsWith('icon-'))
     .substring(5);
@@ -111,6 +113,8 @@ function decorateIcon(elem) {
   img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`;
   img.loading = 'lazy';
   elem.append(img);
+
+  elem.dataset.decorated = true;
 }
 
 /**
@@ -118,6 +122,8 @@ function decorateIcon(elem) {
  * @param {Element} element container element
  */
 function decorateButton(a) {
+  if (a.dataset.decorated) return;
+
   a.title = a.title || a.textContent;
 
   if (a.href !== a.textContent) {
@@ -143,6 +149,8 @@ function decorateButton(a) {
     ) {
       a.className = 'button secondary';
     }
+
+    a.dataset.decorated = true;
   }
 }
 
@@ -528,8 +536,8 @@ export class Brick extends HTMLElement {
     this.observer = new MutationObserver((event) => {
       event.forEach((mutation) => {
         mutation.addedNodes?.forEach((node) => {
-          node.querySelectorAll?.('.icon').forEach(decorateIcon);
-          node.querySelectorAll?.('a').forEach(decorateButton);
+          node.querySelectorAll?.('.icon:not([data-decorated])').forEach(decorateIcon);
+          node.querySelectorAll?.('a:not([data-decorated])').forEach(decorateButton);
         });
       });
     });

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -73,34 +73,10 @@
 }
 
 body {
-  font-size: var(--body-font-size-m);
   margin: 0;
-  font-family: var(--body-font-family);
-  line-height: 1.6;
-  color: var(--text-color);
-  background-color: var(--background-color);
 }
 
 /* Use opacity over display: none to let the browser download LCP image assets */
 body:not([data-status='loaded']) {
   display: none;
-}
-
-header {
-  height: var(--nav-height);
-}
-
-.section {
-  padding: 64px 16px;
-}
-
-@media (width >= 600px) {
-  .section {
-    padding: 64px 32px;
-  }
-}
-
-/* section metadata */
-.section.highlight {
-  background-color: var(--highlight-background-color);
 }


### PR DESCRIPTION
Implementing `aem-root` from the boilerplate https://github.com/adobe-gw2023-project-bricks/aem-wc-boilerplate/pull/33 

Now you are able to decorate `main` as you please in the project. i.e. changing how sections are decorated.

Test URLs:
- Before: https://main--helix-website-wc--adobe-gw2023-project-bricks.hlx.live/home
- After: https://root--helix-website-wc--adobe-gw2023-project-bricks.hlx.live/home
